### PR TITLE
Latest commit does not fix the issue properly

### DIFF
--- a/lib/rubygems/commands/ctags_command.rb
+++ b/lib/rubygems/commands/ctags_command.rb
@@ -22,7 +22,7 @@ class Gem::Commands::CtagsCommand < Gem::Command
 
     Dir.chdir(spec.full_gem_path) do
 
-      if !File.file?('tags') || File.read('tags', 1) != '!'
+      if !(File.file?('tags') && File.read('tags', 1) == '!') && !File.directory?('tags')
         yield "Generating ctags for #{spec.full_name}" if block_given?
         paths = spec.require_paths.select { |p| File.directory?(p) }
         system('ctags', '-R', '--languages=ruby', *paths)


### PR DESCRIPTION
The latest commit 9695af3337f79bcdad1d6dc78790aed5744a9985 fixes the case when there is already a directory named "tags". It works for cases when the file was not present and when there was a directory, but it does not work for cases when file is present.
