### PR TITLE
Don't halt upon error on a single gem

### DIFF
--- a/lib/rubygems/commands/ctags_command.rb
+++ b/lib/rubygems/commands/ctags_command.rb
@@ -37,5 +37,8 @@ class Gem::Commands::CtagsCommand < Gem::Command
       end
 
     end
+  rescue => e
+    raise unless block_given?
+    yield "Failed processing ctags for #{spec.full_name}:\n  (#{e.class}) #{e}"
   end
 end


### PR DESCRIPTION
Gem [backports](https://github.com/marcandre/backports) has directory named `tags`. Thus `gem ctags` halts (and produces very cryptic error):

```
% gem ctags
Generating ctags for  abstract-1.0.0
Generating ctags for  actionmailer-3.0.20
Generating ctags for  actionpack-3.0.20
Generating ctags for  activemodel-3.0.20
Generating ctags for  activerecord-3.0.20
Generating ctags for  activeresource-3.0.20
Generating ctags for  activesupport-3.0.20
Generating ctags for  addressable-2.3.5
Generating ctags for  addressable-2.3.3
Generating ctags for  ansi-1.4.3
Generating ctags for  api_cache-0.2.3
Generating ctags for  arel-2.0.10
Generating ctags for  autoparse-0.3.3
Generating ctags for  awesome_print-1.1.0
ERROR:  While executing gem ... (Errno::EISDIR)
    Is a directory - tags
```

This patch does not halts, instead it just reports an error:

``````
Failed processing ctags for backports-3.3.3:
  (Errno::EISDIR) Is a directory - tags
```
``````
