### PR TITLE
Rewrite `CtagsCommand.index` without `Dir.chdir`

### DIFF
--- a/lib/rubygems/commands/ctags_command.rb
+++ b/lib/rubygems/commands/ctags_command.rb
@@ -24,9 +24,15 @@ class Gem::Commands::CtagsCommand < Gem::Command
     if !(File.file?(tag_file) && File.read(tag_file, 1) == '!') && !File.directory?(tag_file)
       yield "Generating ctags for #{spec.full_name}" if block_given?
       paths = spec.require_paths.
-        map { |p| File.expand_path(p, spec.full_gem_path) }.
+        map { |p|
+          Pathname.new(File.join(spec.full_gem_path, p)).
+            relative_path_from(Pathname.pwd).to_s
+        }.
         select { |p| File.directory?(p) }
-      system('ctags', '-R', '--languages=ruby', '-f', tag_file, *paths)
+      system(
+        'ctags', '-R', '--languages=ruby', '-f', tag_file, '--tag-relative=yes',
+        *paths
+      )
     end
 
     target = File.expand_path('lib/bundler/cli.rb', spec.full_gem_path)


### PR DESCRIPTION
Using `Dir.chdir` triggers warnings like below when installing gems with native extensions through Bundler, when Bundler has been configured to use parallel workers.

```
$ bundle config
Settings are listed in order of priority. The top value will be used.
jobs
Set for the current user (/home/koronen/.bundle/config): "7"
$ bundle install
...
Using tolk 1.6.0
Using uglifier 2.5.3
Using yard 0.8.7.6
with native extensions /home/koronen/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/gem-ctags-1.0.6/lib/rubygems/commands/ctags_command.rb:23: warning: conflicting chdir during another chdir block
/home/koronen/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/gem-ctags-1.0.6/lib/rubygems/commands/ctags_command.rb:23: warning: conflicting chdir during another chdir block
Installing sass 3.2.19
Installing thin 1.6.3
Bundle complete! 37 Gemfile dependencies, 92 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
```

The warnings don't seem to appear when installing gems sequentially using Bundler, or manually using just RubyGems.

The warnings appear to be caused by [`rubygems` calling `Dir.chdir` in `Gem::Ext::Builder.build_extension`](https://github.com/ruby/ruby/blob/v2_2_2/lib/rubygems/ext/builder.rb#L160-L165), wrapping the call to `Dir.chdir` made by `gem-ctags`.

```rb
Dir.chdir extension_dir do
  results = builder.build(extension, @gem_dir, dest_path,
                          results, @build_args, lib_dir)

  verbose { results.join("\n") }
end
```

Here's what [the Ruby documentation](http://ruby-doc.org/core-2.2.2/Dir.html#method-c-chdir) says about nesting calls to `chdir`:

> `chdir` blocks can be nested, but in a multi-threaded program an error will be raised if a thread attempts to open a `chdir` block while another thread has one open.

This patch rewrites `CtagsCommand.index` without calling `Dir.chdir`. Instead, all paths are expanded using `File.expand_path`, and the location of the tags file is passed to `ctags` using the `-f` flag.

Environment details:

```
$ ruby --version
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-linux]
$ gem --version
2.4.7
$ gem list gem-ctags

*** LOCAL GEMS ***

gem-ctags (1.0.6)
$ bundler --version
Bundler version 1.10.3
$ bundle config
Settings are listed in order of priority. The top value will be used.
jobs
Set for the current user (/home/koronen/.bundle/config): "7"
```