### PR TITLE
Require pathname

### DIFF
--- a/lib/rubygems/commands/ctags_command.rb
+++ b/lib/rubygems/commands/ctags_command.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'rubygems/command'
 
 class Gem::Commands::CtagsCommand < Gem::Command


### PR DESCRIPTION
While doing some cleanup after #15 was merged, I encountered the following error:

```
$ gem pristine gem-ctags
Restoring gems to pristine condition...
ERROR:  While executing gem ... (NameError)
    uninitialized constant Gem::Commands::CtagsCommand::Pathname
```

Requiring `pathname` should've been part of 42e658bf4db8d5ce1c5a5db6e6e43f11e2a3175b, but it was unfortunately overlooked.