### PR TITLE
Add language field to tags

### DIFF
--- a/lib/rubygems/commands/ctags_command.rb
+++ b/lib/rubygems/commands/ctags_command.rb
@@ -31,7 +31,7 @@ class Gem::Commands::CtagsCommand < Gem::Command
         }.
         select { |p| File.directory?(p) }
       system(
-        'ctags', '-R', '--languages=ruby', '-f', tag_file, '--tag-relative=yes',
+        'ctags', '-R', '--languages=ruby', '--fields=+l', '-f', tag_file, '--tag-relative=yes',
         *paths
       )
     end


### PR DESCRIPTION
Added command line flag because https://github.com/Valloric/YouCompleteMe requires the language field. Not sure if this is wanted upstream, though. Or if maybe there's a more configurable way to go about this.